### PR TITLE
FIX anidb_info -> categories

### DIFF
--- a/nzedb/db/populate/AniDB.php
+++ b/nzedb/db/populate/AniDB.php
@@ -155,7 +155,7 @@ class AniDB
 			$AniDBAPIArray['related'] = $this->processAPIResponseElement($AniDBAPIXML->relatedanime, 'anime', false);
 			$AniDBAPIArray['creators'] = $this->processAPIResponseElement($AniDBAPIXML->creators, null, false);
 			$AniDBAPIArray['characters'] = $this->processAPIResponseElement($AniDBAPIXML->characters, null, true);
-			$AniDBAPIArray['categories'] = $this->processAPIResponseElement($AniDBAPIXML->categories, null, true);
+			$AniDBAPIArray['categories'] = $this->processAPIResponseElement($AniDBAPIXML->tags, null, true);
 
 			$episodeArray = [];
 			if ($AniDBAPIXML->episodes && $AniDBAPIXML->episodes->episode[0]->attributes()) {


### PR DESCRIPTION
I don't know if anidb changed this from categories, or just removed it altogether.  What I do know is it leaves categories blank, and tags looks an awful like categories so I adjusted it to scape the tags for this field.

Addresses issue #.

Changes made by this pull request.
Instead of parsing for categories from the AniDB API, since its non existent it parses tags for the categories  